### PR TITLE
Added lookside for torch.compile

### DIFF
--- a/thunder/core/jit_ext.py
+++ b/thunder/core/jit_ext.py
@@ -774,6 +774,12 @@ def _general_jit_setattr_lookaside(obj: Any, name: str, value: Any):
         return res
     return res
 
+@general_jit_lookaside(torch.compile)
+def torch_compile_lookaside(*args, **kwargs):
+    return do_raise(NotImplementedError(
+        "Using torch.compile within a function to be JIT-compiled by Thunder is not supported. "
+        "Please remove the call to torch.compile or apply it outside the function."
+    ))
 
 # TODO Expand on this
 @interpreter_needs_wrap


### PR DESCRIPTION
<details>
 <summary><b>Before submitting</b></summary>

- [ X] Was this discussed/approved via a Github issue? (no need for typos and docs improvements) - Yes
- [ X] Did you read the [contributor guideline](https://github.com/Lightning-AI/pytorch-lightning/blob/main/.github/CONTRIBUTING.md), Pull Request section? - Yes
- [ ] Did you make sure to update the docs? - No
- [ ] Did you write any new necessary tests? - No

</details>

## What does this PR do?

Fixes #186

- Added a lookaside function `torch_compile_lookaside` in `thunder/core/jit_ext.py` to handle cases where `torch.compile` is used within a function intended for JIT compilation.
- The lookaside raises a `NotImplementedError` with a clear message, guiding users to remove the `torch.compile` call or apply it outside the function.
- Ensured the function is decorated with `@general_jit_lookaside(torch.compile)` to integrate it properly with Thunder's JIT infrastructure.
## PR review

Anyone in the community is free to review the PR once the tests have passed.
If we didn't discuss your PR in Github issues there's a high chance it will not be merged.

## Did you have fun?

Sure did!
